### PR TITLE
implementing clear and fixing variable scoping

### DIFF
--- a/backbone.memento.js
+++ b/backbone.memento.js
@@ -28,9 +28,24 @@ Backbone.Memento = (function(model){
 
   function removeAttributes(model, attrsToRemove){
     for (var index in attrsToRemove){
-      attr = removedAttrs[index];
+      attr = attrsToRemove[index];
       model.unset(attr);
     }
+  }
+
+  function restoreState(last){
+      //get the previous state
+      var attrs = attributeStack[last];
+
+      //handle removing attributes that were added
+      var removedAttrs = getRemovedAttrDiff(attrs, model.toJSON());
+      removeAttributes(model, removedAttrs);
+
+      //restore the previous state
+      model.set(attrs);
+
+      //destroy the no-longer-current state
+      delete attributeStack[last];
   }
   
   return {
@@ -45,18 +60,15 @@ Backbone.Memento = (function(model){
       if (last < 0)
         return null;
 
-      //get the previous state
-      attrs = attributeStack[last];
+      restoreState(last);
+    },
 
-      //handle removing attributes that were added
-      removedAttrs = getRemovedAttrDiff(attrs, model.toJSON());
-      removeAttributes(model, removedAttrs);
+    clear: function(){
+      if(attributeStack.length === 0){
+        return null;
+      }
 
-      //restore the previous state
-      model.set(attrs);
-
-      //destroy the no-longer-current state
-      delete attributeStack[last];
+      restoreState(0);
     }
   }
 });

--- a/spec/javascripts/memento.spec.js
+++ b/spec/javascripts/memento.spec.js
@@ -63,4 +63,39 @@ describe("memento", function(){
       expect(changed).toBeTruthy();
     });
   });
+  
+  describe("when clearing", function(){
+    it("should restore to first memento given successive save points", function(){
+      var changed = false;
+      this.model.set({foo: "bar"});
+      this.model.store();
+      this.model.set({foo: "baz"});
+      this.model.store();
+      this.model.set({foo: "qux"});
+      this.model.store();
+
+      this.model.bind("change:foo", function(){
+        changed = true;
+      });
+
+      expect(this.model.get('foo')).toBe('qux');
+      this.model.clear();
+      expect(changed).toBeTruthy();
+      expect(this.model.get('foo')).toBe('bar');
+    });
+
+
+    it("should do nothing given no store point", function(){
+      var changed = false;
+      this.model.set({foo: "bar"});
+
+      this.model.bind("change:foo", function(){
+        changed = true;
+      });
+      this.model.clear();
+
+      expect(this.model.get('foo')).toBe('bar');
+      expect(changed).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
Hi Derick,
I've implemented clear, actually started by calling it 'reset' because i needed it, but then saw that the model already contained such a thing and it was not implemented.

some more notes about code in commit body:
https://github.com/jondot/backbone.memento/commit/4537b9fa0972ceff73e49a65ad5cbfa8dc9fbf3a

Hope this helps!
