### PR TITLE
support for using extensions to Backbone.Model

### DIFF
--- a/backbone.memento.js
+++ b/backbone.memento.js
@@ -46,7 +46,7 @@ Backbone.Memento = (function(Backbone, _){
   // restoring attributes, on models and collections
   // ----------------------------
   var TypeHelper = function(structure){
-    if (structure instanceof Backbone.Model) {
+    if (structure instanceof Backbone.Model || !(structure.reset)) {
       this.removeAttr = function(data){ structure.unset(data); };
       this.restore = function(data){ structure.set(data); };
     } else {


### PR DESCRIPTION
I'm using another Backbone.js plugin which provides an extension of the Backbone.Model class. As a result,

``` JavaScript
   structure instanceof Backbone.Model
```

is returning false. Which subsequently results in an error when I'm calling model.restore() as memento attempts to call the reset() method which doesn't exist on my Model. This change to include a check for .reset method does work for me. 

If there's a better way to do this to provide support for extensions to Backbone.Model, I'd be interested to learn it.
